### PR TITLE
Workflow and Nuget deploy setup

### DIFF
--- a/.github/workflows/base-build-and-test.yml
+++ b/.github/workflows/base-build-and-test.yml
@@ -1,0 +1,201 @@
+name: Base Build and Test
+
+on:
+  workflow_call:
+    inputs:
+      is-prerelease:
+        description: 'Whether this is a prerelease build'
+        required: true
+        type: boolean
+      should-publish:
+        description: 'Whether to publish the package'
+        required: true
+        type: boolean
+      version:
+        description: 'Package version to use'
+        required: false
+        type: string
+    secrets:
+      NUGET_API_KEY:
+        description: 'NuGet API key for publishing'
+        required: true
+      COVERAGE_THRESHOLD:
+        description: 'Minimum code coverage threshold'
+        required: false
+
+env:
+  DOTNET_VERSION: '8.0.x'
+  SOLUTION_PATH: './TacoMapper.sln'
+  PROJECT_PATH: './lib/TacoMapper.csproj'
+  TEST_PATH: './unit-tests/TacoMapper.Tests.csproj'
+  COVERAGE_THRESHOLD: ${{ secrets.COVERAGE_THRESHOLD || '70' }}
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: Restore dependencies
+      run: dotnet restore ${{ env.SOLUTION_PATH }}
+
+    - name: Build solution
+      run: dotnet build ${{ env.SOLUTION_PATH }} --configuration Release --no-restore
+
+    - name: Install coverage tools
+      run: |
+        dotnet tool install --global coverlet.console
+        dotnet tool install --global dotnet-reportgenerator-globaltool
+
+    - name: Run tests with coverage
+      run: |
+        dotnet test ${{ env.TEST_PATH }} \
+          --configuration Release \
+          --no-build \
+          --collect:"XPlat Code Coverage" \
+          --results-directory ./coverage \
+          --logger trx \
+          --verbosity normal
+
+    - name: Generate coverage report
+      run: |
+        reportgenerator \
+          -reports:"./coverage/**/coverage.cobertura.xml" \
+          -targetdir:"./coverage/report" \
+          -reporttypes:"Html;Cobertura;TextSummary"
+
+    - name: Check coverage threshold
+      run: |
+        COVERAGE=$(grep -oP 'Line coverage: \K[0-9.]+' ./coverage/report/Summary.txt | head -1)
+        echo "Current coverage: ${COVERAGE}%"
+        echo "Required threshold: ${{ env.COVERAGE_THRESHOLD }}%"
+        
+        if (( $(echo "$COVERAGE < ${{ env.COVERAGE_THRESHOLD }}" | bc -l) )); then
+          echo "❌ Coverage ${COVERAGE}% is below threshold ${{ env.COVERAGE_THRESHOLD }}%"
+          exit 1
+        else
+          echo "✅ Coverage ${COVERAGE}% meets threshold ${{ env.COVERAGE_THRESHOLD }}%"
+        fi
+
+    - name: Upload coverage reports
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: ./coverage/report/
+
+    - name: Set version for prerelease
+      if: inputs.is-prerelease
+      run: |
+        if [ -n "${{ inputs.version }}" ]; then
+          # Use provided version for prerelease
+          VERSION="${{ inputs.version }}-pre${{ github.run_number }}"
+        else
+          # Generate version with timestamp for prerelease
+          TIMESTAMP=$(date -u +"%Y%m%d%H%M%S")
+          VERSION="1.0.0-pre${{ github.run_number }}-${TIMESTAMP}"
+        fi
+        echo "PACKAGE_VERSION=${VERSION}" >> $GITHUB_ENV
+        echo "Generated prerelease version: ${VERSION}"
+
+    - name: Set version for release
+      if: ${{ !inputs.is-prerelease }}
+      run: |
+        if [ -n "${{ inputs.version }}" ]; then
+          # Use provided version for release
+          VERSION="${{ inputs.version }}"
+        else
+          # For release, use semantic versioning based on build number
+          VERSION="1.0.${{ github.run_number }}"
+        fi
+        echo "PACKAGE_VERSION=${VERSION}" >> $GITHUB_ENV
+        echo "Generated release version: ${VERSION}"
+
+    - name: Update project version
+      run: |
+        # Update the version in the project file
+        sed -i "s/<Version>.*<\/Version>/<Version>${PACKAGE_VERSION}<\/Version>/" ${{ env.PROJECT_PATH }}
+        echo "Updated project version to: ${PACKAGE_VERSION}"
+
+    - name: Build NuGet package
+      run: |
+        dotnet pack ${{ env.PROJECT_PATH }} \
+          --configuration Release \
+          --no-build \
+          --output ./artifacts \
+          -p:PackageVersion=${{ env.PACKAGE_VERSION }}
+
+    - name: Upload NuGet package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: nuget-package
+        path: ./artifacts/*.nupkg
+
+    - name: Publish to NuGet
+      if: inputs.should-publish
+      run: |
+        dotnet nuget push ./artifacts/*.nupkg \
+          --api-key ${{ secrets.NUGET_API_KEY }} \
+          --source https://api.nuget.org/v3/index.json \
+          --skip-duplicate    # Only create GitHub release if no custom version is provided (CI scenario)
+    # For manual releases, the calling workflow handles release creation
+    - name: Create GitHub Release
+      if: inputs.should-publish && !inputs.is-prerelease && inputs.version == ''
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v${{ env.PACKAGE_VERSION }}
+        name: Release v${{ env.PACKAGE_VERSION }}
+        body: |
+          ## TacoMapper v${{ env.PACKAGE_VERSION }}
+          
+          🌮 **New Release of TacoMapper!**
+          
+          ### What's Changed
+          - Automatic release from CI/CD pipeline
+          - All tests passing with ≥${{ env.COVERAGE_THRESHOLD }}% code coverage
+          
+          ### Package Information
+          - **NuGet Package**: [TacoMapper v${{ env.PACKAGE_VERSION }}](https://www.nuget.org/packages/TacoMapper/${{ env.PACKAGE_VERSION }})
+          - **Target Framework**: .NET 8.0
+          
+          ### Installation          ```bash
+          dotnet add package TacoMapper --version ${{ env.PACKAGE_VERSION }}
+          ```
+          
+          Happy mapping! 🌮✨
+
+    - name: Comment on PR (if applicable)
+      if: inputs.is-prerelease && github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const { context } = require('@actions/core');
+          const message = `
+          🌮 **TacoMapper Prerelease Package Created!**
+          
+          📦 **Package Version**: \`${{ env.PACKAGE_VERSION }}\`
+          ✅ **Tests**: All passed
+          📊 **Coverage**: ≥${{ env.COVERAGE_THRESHOLD }}%
+          
+          You can test this prerelease version:
+          \`\`\`bash
+          dotnet add package TacoMapper --version ${{ env.PACKAGE_VERSION }} --prerelease
+          \`\`\`
+          `;
+          
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: message
+          });

--- a/.github/workflows/ci-prerelease.yml
+++ b/.github/workflows/ci-prerelease.yml
@@ -1,0 +1,32 @@
+name: CI - Prerelease Deploy
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    types: [ closed ]
+
+# Only run on merged PRs or direct pushes to main
+jobs:
+  check-pr-merged:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR Merged Check
+        run: |
+          echo "✅ Building and deploying prerelease package"
+          echo "Event: ${{ github.event_name }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "PR #${{ github.event.pull_request.number }} was merged"
+          fi
+
+  deploy-prerelease:
+    needs: check-pr-merged
+    uses: ./.github/workflows/base-build-and-test.yml
+    with:
+      is-prerelease: true
+      should-publish: true
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      COVERAGE_THRESHOLD: ${{ secrets.COVERAGE_THRESHOLD }}

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,208 @@
+name: Manual Release Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version increment type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      include_commits_since:
+        description: 'Include commits since last release (days ago)'
+        required: false
+        default: '30'
+        type: string
+
+jobs:
+  generate-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_notes: ${{ steps.version.outputs.release_notes }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate version and release notes
+        id: version
+        run: |
+          # Fetch all tags and commits
+          git fetch --tags --unshallow || git fetch --tags
+          
+          # Get the latest tag (if any)
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "Latest tag: $LATEST_TAG"
+          
+          # Remove 'v' prefix if present
+          LATEST_VERSION=${LATEST_TAG#v}
+          echo "Latest version: $LATEST_VERSION"
+          
+          # Parse version components
+          IFS='.' read -ra VERSION_PARTS <<< "$LATEST_VERSION"
+          MAJOR=${VERSION_PARTS[0]:-0}
+          MINOR=${VERSION_PARTS[1]:-0}
+          PATCH=${VERSION_PARTS[2]:-0}
+          
+          echo "Current version components: $MAJOR.$MINOR.$PATCH"
+          
+          # Increment version based on input
+          case "${{ github.event.inputs.version_type }}" in
+            "major")
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            "minor")
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            "patch")
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+          
+          NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+          echo "New version: $NEW_VERSION"
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          
+          # Generate release notes from commits
+          DAYS_BACK="${{ github.event.inputs.include_commits_since }}"
+          SINCE_DATE=$(date -d "$DAYS_BACK days ago" +%Y-%m-%d)
+          
+          echo "Generating release notes for commits since: $SINCE_DATE"
+          
+          # Get commits since the last tag or since specified days
+          if [ "$LATEST_TAG" != "v0.0.0" ]; then
+            COMMIT_RANGE="$LATEST_TAG..HEAD"
+            echo "Using commit range: $COMMIT_RANGE"
+          else
+            COMMIT_RANGE="--since=$SINCE_DATE"
+            echo "Using date range: $COMMIT_RANGE"
+          fi
+          
+          # Generate commit log
+          COMMITS=$(git log $COMMIT_RANGE --pretty=format:"- %s (%h)" --reverse)
+          
+          if [ -z "$COMMITS" ]; then
+            COMMITS="- No new commits since last release"
+          fi
+          
+          # Create release notes
+          RELEASE_NOTES=$(cat << EOF
+          ## 🚀 What's New in v$NEW_VERSION
+          
+          This release includes the following changes:
+          
+          ### 📝 Commits
+          $COMMITS
+          
+          ### 📊 Repository Stats
+          - **Release Date**: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+          - **Version Type**: ${{ github.event.inputs.version_type }} release
+          - **Commits Included**: $(echo "$COMMITS" | wc -l) commits
+          - **Previous Version**: $LATEST_VERSION
+          EOF
+          )
+          
+          # Save release notes to output
+          echo "release_notes<<EOF" >> $GITHUB_OUTPUT
+          echo "$RELEASE_NOTES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          
+          # Also create a summary for the workflow
+          echo "## 🌮 TacoMapper Release v$NEW_VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version Type**: ${{ github.event.inputs.version_type }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Previous Version**: $LATEST_VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "**New Version**: $NEW_VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Recent Changes:" >> $GITHUB_STEP_SUMMARY
+          echo "$COMMITS" >> $GITHUB_STEP_SUMMARY
+
+  deploy-release-with-version:
+    needs: generate-version
+    uses: ./.github/workflows/base-build-and-test.yml
+    with:
+      is-prerelease: false
+      should-publish: true
+      version: ${{ needs.generate-version.outputs.version }}
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      COVERAGE_THRESHOLD: ${{ secrets.COVERAGE_THRESHOLD }}
+
+  create-enhanced-release:
+    needs: [generate-version, deploy-release-with-version]
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create Enhanced GitHub Release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ needs.generate-version.outputs.version }}
+          name: TacoMapper v${{ needs.generate-version.outputs.version }}
+          body: |
+            # 🌮 TacoMapper v${{ needs.generate-version.outputs.version }}
+            
+            ${{ needs.generate-version.outputs.release_notes }}
+            
+            ## 📊 Quality Metrics
+            - ✅ All tests passing
+            - 📈 Code coverage ≥ 70%
+            - 🔍 Static analysis passed
+            - 🏗️ Built with .NET 8.0
+              ## 📦 Installation
+            
+            ### NuGet Package Manager
+            ```bash
+            dotnet add package TacoMapper --version ${{ needs.generate-version.outputs.version }}
+            ```
+            
+            ### Package Manager Console (Visual Studio)
+            ```powershell
+            Install-Package TacoMapper -Version ${{ needs.generate-version.outputs.version }}
+            ```
+            
+            ### PackageReference (in .csproj)
+            ```xml
+            <PackageReference Include="TacoMapper" Version="${{ needs.generate-version.outputs.version }}" />
+            ```
+            
+            ## 🌮 Quick Start
+            
+            ```csharp
+            using TacoMapper;
+            
+            var mapper = new ObjectMapper();
+            
+            // Basic mapping
+            var result = mapper.Map<Source, Target>(source)
+                .To(target => target.Name, source => source.FullName)
+                .Execute();
+            
+            // Conditional mapping
+            var result = mapper.Map<Source, Target>(source)
+                .To(target => target.Status, source => source.IsActive ? "Active" : "Inactive")
+                .When(source => source.IsValid)
+                .Execute();
+            ```
+            
+            ## 📚 Documentation
+            - [GitHub Repository](https://github.com/${{ github.repository }})
+            - [NuGet Package](https://www.nuget.org/packages/TacoMapper/${{ needs.generate-version.outputs.version }})
+            
+            ## 🤝 Contributing
+            We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.md) for details.
+              ---
+            **Happy Mapping!** 🌮✨

--- a/icon.png
+++ b/icon.png
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?><Error><Code>AuthenticationFailed</Code><Message>Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature.
+RequestId:73c5614a-201e-002d-3282-e41fa1000000
+Time:2025-06-23T21:01:56.3689287Z</Message><AuthenticationErrorDetail>Signed expiry time [Mon, 23 Jun 2025 20:14:27 GMT] must be after signed start time [Mon, 23 Jun 2025 21:01:56 GMT]</AuthenticationErrorDetail></Error>

--- a/lib/TacoMapper.csproj
+++ b/lib/TacoMapper.csproj
@@ -1,5 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">  <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -7,15 +6,26 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>TacoMapper</PackageId>
     <Version>1.0.0</Version>
-    <Authors>Your Name</Authors>
+    <Authors>Gustavo Barrientos</Authors>
+    <Company>TacoMapper</Company>
+    <Product>TacoMapper</Product>
     <Description>A lightweight object mapper with fluent API supporting basic, conditional, and combine mapping</Description>
-    <PackageTags>mapper;object-mapper;fluent-api;lightweight;taco</PackageTags>
+    <PackageTags>tacomapper;object-mapper;fluent-api;lightweight;taco;mapping;dotnet</PackageTags>
+    <PackageProjectUrl>https://github.com/tavobarrientos/TacoMapper</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/tavobarrientos/TacoMapper</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageIcon>icon.png</PackageIcon>
+    <PackageReleaseNotes>See https://github.com/tavobarrientos/TacoMapper/releases for release notes</PackageReleaseNotes>
+    <Copyright>Copyright © $(Authors) $([System.DateTime]::Now.Year)</Copyright>
+    <AssemblyVersion>$(Version)</AssemblyVersion>
+    <FileVersion>$(Version)</FileVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="Program.cs" />
-    <Compile Remove="MapperTests.cs" />
-    <Compile Remove="TestModels.cs" />
+    <None Include="../README.md" Pack="true" PackagePath="\" Condition="Exists('../README.md')" />
+    <None Include="../icon.png" Pack="true" PackagePath="\" Condition="Exists('../icon.png')" />
   </ItemGroup>
-
 </Project>

--- a/unit-tests/TacoMapper.Tests.csproj
+++ b/unit-tests/TacoMapper.Tests.csproj
@@ -8,11 +8,18 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../lib/TacoMapper.csproj" />


### PR DESCRIPTION
This pull request introduces several enhancements to the CI/CD workflows for the `TacoMapper` project, improves the project's metadata in the `.csproj` files, and adds new dependencies for code coverage in the unit tests. The key changes include the creation of reusable workflows for build, test, and deployment, updates to project metadata for better package distribution, and integration of code coverage tools.

### CI/CD Workflow Enhancements:
* [`.github/workflows/base-build-and-test.yml`](diffhunk://#diff-8a482ce3c4d11c60314f595af39cdf086352ca2d7965962689041879bcc13b55R1-R201): Added a reusable workflow for building, testing, and publishing the `TacoMapper` package. Includes code coverage checks, automated versioning, and NuGet publishing.
* [`.github/workflows/ci-prerelease.yml`](diffhunk://#diff-c255ca4e287562ef0e7b90ce99721d3e9e22f6d2dcc27f1561740c97bc36fb14R1-R32): Created a workflow for deploying prerelease packages triggered by merged pull requests or direct pushes to the `main` branch. Utilizes the base build-and-test workflow.
* [`.github/workflows/manual-release.yml`](diffhunk://#diff-15fb1f5c1e9076ac354d7b3c7a9e3d508e100c550bfbabd66ec943ea883bf0d9R1-R208): Added a manual release workflow with support for version increment types (`patch`, `minor`, `major`) and release notes generation based on recent commits.

### Project Metadata Improvements:
* [`lib/TacoMapper.csproj`](diffhunk://#diff-9598ce4a4158489aa16859a8c04e0cbf6d65a1ab5280ae970975db4618ce895aL1-L20): Updated metadata such as `Authors`, `Company`, `PackageTags`, `RepositoryUrl`, and `PackageLicenseExpression`. Added support for packaging README, icon, and release notes.
* [`unit-tests/TacoMapper.Tests.csproj`](diffhunk://#diff-aedd4e55bf61f193f013160c1219a92593cc4b327143129110c6a8cb9cea6e59L11-R22): Added `coverlet.collector` and `coverlet.msbuild` dependencies to enable code coverage reporting during tests.

### File Addition:
* [`icon.png`](diffhunk://#diff-452a6264ad5b14bd220ff9842d11c67f54d440eb27f3c3e90515ec090b907b09R1-R3): Added a placeholder for the package icon, although the file content appears to be corrupted and may need correction.